### PR TITLE
#15 - 必要箇所以外のuse clientをやめる

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,6 @@
-"use client";
-
 import Footer from "@/components/footer/footer";
 import Header from "@/components/header/header";
 import Analytics from "@/components/Analytics/Analytics";
-import { createTheme, ThemeProvider } from "@mui/material";
 import { Viewport } from "next";
 import { Zen_Kaku_Gothic_New } from "next/font/google";
 import { ReactNode, Suspense } from "react";
@@ -19,14 +16,6 @@ export const viewport: Viewport = {
   width: "device-width",
 };
 
-const theme = createTheme({
-  typography: {
-    fontFamily: ["__Zen_Kaku_Gothic_New_246353", "Roboto", "sans-serif"].join(
-      ","
-    ),
-  },
-});
-
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="ja">
@@ -36,16 +25,14 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           href="https://cdnjs.cloudflare.com/ajax/libs/tocbot/4.11.1/tocbot.css"
         />
       </head>
-      <ThemeProvider theme={theme}>
         <body className={ZenKakuGothicNewFont.className}>
           <Suspense fallback={null}>
             <Analytics />
           </Suspense>
           <Header />
-          {children}
+            {children}
           <Footer />
         </body>
-      </ThemeProvider>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,100 +1,11 @@
-"use client";
-
 import Container from "@/components/container/container";
-import ContentSection from "@/components/ContentSection/ContentSection";
 import DiscordWidget from "@/components/DiscordWidget/DiscordWidget";
 import FAQ from "@/components/FAQ/FAQ";
 import Hero from "@/components/hero/hero";
 import MemberChart from "@/components/MemberChart/MemberChart";
 import SectionHeader from "@/components/SectionHeader/SectionHeader";
-import { useEffect, useState } from "react";
-import Slider, { CustomArrowProps } from "react-slick";
-import "slick-carousel/slick/slick-theme.css";
-import "slick-carousel/slick/slick.css";
 import styles from "./page.module.css";
-
-const NextArrow = (props: CustomArrowProps) => {
-  const { className, style, onClick } = props;
-  const [isVisible, setIsVisible] = useState(true);
-
-  useEffect(() => {
-    const handleResize = () => {
-      if (window.innerWidth <= 768) {
-        setIsVisible(false);
-      } else {
-        setIsVisible(true);
-      }
-    };
-
-    handleResize();
-    window.addEventListener("resize", handleResize);
-
-    return () => {
-      window.removeEventListener("resize", handleResize);
-    };
-  }, []);
-
-  if (!isVisible) return null;
-  return (
-    <div
-      className={className}
-      style={{
-        ...style,
-        background: "black",
-        borderRadius: "50%",
-      }}
-      onClick={onClick}
-    />
-  );
-};
-
-const PrevArrow = (props: CustomArrowProps) => {
-  const { className, style, onClick } = props;
-  const [isVisible, setIsVisible] = useState(true);
-
-  useEffect(() => {
-    const handleResize = () => {
-      if (window.innerWidth <= 768) {
-        setIsVisible(false);
-      } else {
-        setIsVisible(true);
-      }
-    };
-
-    handleResize();
-    window.addEventListener("resize", handleResize);
-
-    return () => {
-      window.removeEventListener("resize", handleResize);
-    };
-  }, []);
-
-  if (!isVisible) return null;
-  return (
-    <div
-      className={className}
-      style={{
-        ...style,
-        background: "black",
-        borderRadius: "50%",
-      }}
-      onClick={onClick}
-    />
-  );
-};
-
-const settings = {
-  dots: true,
-  infinite: true,
-  speed: 500,
-  slidesToShow: 1,
-  slidesToScroll: 1,
-  arrows: true,
-  nextArrow: <NextArrow />,
-  prevArrow: <PrevArrow />,
-  autoplay: true,
-  autoplaySpeed: 10000, //10s
-};
+import Activities from "@/components/Activities/Activities"
 
 const HomePage = () => {
   return (
@@ -126,43 +37,7 @@ const HomePage = () => {
             </div>
           </div>
         </div>
-
-        <div id="activity" className={styles.box}>
-          <div className={styles.centerText}>
-            <SectionHeader title="ACTIVITY" subtitle="活動紹介" />
-          </div>
-
-          <Slider {...settings}>
-            <div>
-              <ContentSection
-                number="01"
-                title="定例会"
-                description="メンバーが学んだ内容や挑戦したことをアウトプットし、意見交換を行います"
-                pointDescription="月３回の定例会で定期的にアウトプットができる点
-毎月10,20,30日の夜にオンラインで開催しており、他の部活やアルバイトで忙しい学生でも参加しやすい"
-                imageUrl="/teirei.jpg"
-              />
-            </div>
-            <div>
-              <ContentSection
-                number="02"
-                title="勉強会"
-                description="GitやJavaScriptなどの技術に関する勉強会を開催します"
-                pointDescription="様々なバックグラウンドの学生が所属しており、プログラミングやネットワーク、サーバ、セキュリティなど幅広い知識を身につけられます"
-                imageUrl="/gitstudy.jpg"
-              />
-            </div>
-            <div>
-              <ContentSection
-                number="03"
-                title="イベント参加"
-                description="チームでCTF（Capture The Flag）やハッカソンなどのイベントに参加し、実践的なスキルを磨きます"
-                pointDescription="意欲的な学生が多く、チームも作りやすい環境です。気軽に参加を呼びかけられます"
-                imageUrl="/hack.png"
-              />
-            </div>
-          </Slider>
-        </div>
+        <Activities></Activities>
 
         <div id="member" className={styles.box}>
           <div className={styles.centerText}>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -37,7 +37,7 @@ const HomePage = () => {
             </div>
           </div>
         </div>
-        <Activities></Activities>
+        <Activities />
 
         <div id="member" className={styles.box}>
           <div className={styles.centerText}>

--- a/components/Activities/Activities.tsx
+++ b/components/Activities/Activities.tsx
@@ -1,0 +1,135 @@
+"use client"
+
+import styles from "./activities.module.css";
+import SectionHeader from "@/components/SectionHeader/SectionHeader";
+import ContentSection from "@/components/ContentSection/ContentSection";
+import { useEffect, useState } from "react";
+import Slider, { CustomArrowProps } from "react-slick";
+import "slick-carousel/slick/slick-theme.css";
+import "slick-carousel/slick/slick.css";
+
+const NextArrow = (props: CustomArrowProps) => {
+  const { className, style, onClick } = props;
+  const [isVisible, setIsVisible] = useState(true);
+
+  useEffect(() => {
+    const handleResize = () => {
+      if (window.innerWidth <= 768) {
+        setIsVisible(false);
+      } else {
+        setIsVisible(true);
+      }
+    };
+
+    handleResize();
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
+
+  if (!isVisible) return null;
+  return (
+    <div
+      className={className}
+      style={{
+        ...style,
+        background: "black",
+        borderRadius: "50%",
+      }}
+      onClick={onClick}
+    />
+  );
+};
+
+const PrevArrow = (props: CustomArrowProps) => {
+  const { className, style, onClick } = props;
+  const [isVisible, setIsVisible] = useState(true);
+
+  useEffect(() => {
+    const handleResize = () => {
+      if (window.innerWidth <= 768) {
+        setIsVisible(false);
+      } else {
+        setIsVisible(true);
+      }
+    };
+
+    handleResize();
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
+
+  if (!isVisible) return null;
+  return (
+    <div
+      className={className}
+      style={{
+        ...style,
+        background: "black",
+        borderRadius: "50%",
+      }}
+      onClick={onClick}
+    />
+  );
+};
+
+const settings = {
+  dots: true,
+  infinite: true,
+  speed: 500,
+  slidesToShow: 1,
+  slidesToScroll: 1,
+  arrows: true,
+  nextArrow: <NextArrow />,
+  prevArrow: <PrevArrow />,
+  autoplay: true,
+  autoplaySpeed: 10000, //10s
+};
+
+const Activities = () => {
+  return (
+        <div id="activity" className={styles.box}>
+          <div className={styles.centerText}>
+            <SectionHeader title="ACTIVITY" subtitle="活動紹介" />
+          </div>
+
+          <Slider {...settings}>
+            <div>
+              <ContentSection
+                number="01"
+                title="定例会"
+                description="メンバーが学んだ内容や挑戦したことをアウトプットし、意見交換を行います"
+                pointDescription="月３回の定例会で定期的にアウトプットができる点
+毎月10,20,30日の夜にオンラインで開催しており、他の部活やアルバイトで忙しい学生でも参加しやすい"
+                imageUrl="/teirei.jpg"
+              />
+            </div>
+            <div>
+              <ContentSection
+                number="02"
+                title="勉強会"
+                description="GitやJavaScriptなどの技術に関する勉強会を開催します"
+                pointDescription="様々なバックグラウンドの学生が所属しており、プログラミングやネットワーク、サーバ、セキュリティなど幅広い知識を身につけられます"
+                imageUrl="/gitstudy.jpg"
+              />
+            </div>
+            <div>
+              <ContentSection
+                number="03"
+                title="イベント参加"
+                description="チームでCTF（Capture The Flag）やハッカソンなどのイベントに参加し、実践的なスキルを磨きます"
+                pointDescription="意欲的な学生が多く、チームも作りやすい環境です。気軽に参加を呼びかけられます"
+                imageUrl="/hack.png"
+              />
+            </div>
+          </Slider>
+        </div>
+  )
+}
+
+export default Activities

--- a/components/Activities/Activities.tsx
+++ b/components/Activities/Activities.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { clsx } from "clsx";
 import styles from "./activities.module.css";
 import SectionHeader from "@/components/SectionHeader/SectionHeader";
 import ContentSection from "@/components/ContentSection/ContentSection";
@@ -10,29 +11,9 @@ import "slick-carousel/slick/slick.css";
 
 const NextArrow = (props: CustomArrowProps) => {
   const { className, style, onClick } = props;
-  const [isVisible, setIsVisible] = useState(true);
-
-  useEffect(() => {
-    const handleResize = () => {
-      if (window.innerWidth <= 768) {
-        setIsVisible(false);
-      } else {
-        setIsVisible(true);
-      }
-    };
-
-    handleResize();
-    window.addEventListener("resize", handleResize);
-
-    return () => {
-      window.removeEventListener("resize", handleResize);
-    };
-  }, []);
-
-  if (!isVisible) return null;
   return (
     <div
-      className={className}
+      className={clsx(styles.arrowBtn, className)}
       style={{
         ...style,
         background: "black",
@@ -46,28 +27,9 @@ const NextArrow = (props: CustomArrowProps) => {
 const PrevArrow = (props: CustomArrowProps) => {
   const { className, style, onClick } = props;
   const [isVisible, setIsVisible] = useState(true);
-
-  useEffect(() => {
-    const handleResize = () => {
-      if (window.innerWidth <= 768) {
-        setIsVisible(false);
-      } else {
-        setIsVisible(true);
-      }
-    };
-
-    handleResize();
-    window.addEventListener("resize", handleResize);
-
-    return () => {
-      window.removeEventListener("resize", handleResize);
-    };
-  }, []);
-
-  if (!isVisible) return null;
   return (
     <div
-      className={className}
+      className={clsx(styles.arrowBtn, className)}
       style={{
         ...style,
         background: "black",

--- a/components/Activities/activities.module.css
+++ b/components/Activities/activities.module.css
@@ -1,0 +1,8 @@
+.centerText {
+  text-align: center;
+  margin-bottom: 15px;
+}
+
+.box {
+  margin-bottom: var(--space-lg);
+}

--- a/components/Activities/activities.module.css
+++ b/components/Activities/activities.module.css
@@ -6,3 +6,9 @@
 .box {
   margin-bottom: var(--space-lg);
 }
+
+@media screen and (max-width: 768px) {
+  .arrowBtn {
+    display: none!important;
+  }
+}

--- a/components/hero/hero.tsx
+++ b/components/hero/hero.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import ie from "@/public/ichipiroexplorer.png";
 import Image from "next/legacy/image";
 import { useEffect, useState } from "react";

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@react-three/flex": "^1.0.1",
         "autoprefixer": "^10.4.19",
         "bootstrap": "^5.3.3",
+        "clsx": "^2.1.1",
         "framer-motion": "^11.2.11",
         "next": "^14.2.33",
         "postcss": "^8.4.38",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@react-three/flex": "^1.0.1",
     "autoprefixer": "^10.4.19",
     "bootstrap": "^5.3.3",
+    "clsx": "^2.1.1",
     "framer-motion": "^11.2.11",
     "next": "^14.2.33",
     "postcss": "^8.4.38",


### PR DESCRIPTION
## このPRについて
#15 の作業をします．
まだDraftです．
## 変更したもの
- layout.tsxをServer Component化
- page.tsxをServer Component化
- カルーセルのnext/prev切り替えボタンの画面サイズによる表示状態の切り替えをJSイベントリスナからCSSメディアクエリに書き換え
	- `!important` を使用，望ましくはないため別の方法を検討
	- Embla Carouselなど
## 既知の問題
- Zen Kaku Gothic Newのフォールバックフォントの設定を外しています．
フォールバックにシステムフォントが使用されます．別のPRで修正予定です．
## 依存関係
このPRをマージすると， #18 がマージできます．